### PR TITLE
Add python on "name" and "summary" to differentiate from XML version

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="metadata.tvshows.themoviedb.org.python"
-  name="TMDb TV Shows"
+  name="TMDb TV Show Python"
   version="1.3.14"
   provider-name="Team Kodi">
   <requires>
@@ -12,7 +12,7 @@
     <news>1.3.14
 fix for named seasons in NFO files being ignored
 	</news>
-    <summary lang="en_GB">Fetch TV Show metadata from themoviedb.org</summary>
+    <summary lang="en_GB">Python TMDB TV show Scraper</summary>
     <description lang="en_GB">The Movie Database (TMDb) is a community built movie and TV database. Every piece of data has been added by our amazing community dating back to 2008. TMDb's strong international focus and breadth of data is largely unmatched and something we're incredibly proud of. Put simply, we live and breathe community and that's precisely what makes us different.</description>
     <platform>all</platform>
     <license>GPL-3.0-or-later</license>


### PR DESCRIPTION
When selecting which scraper to use, there is nothing to differentiate from XML version.