### PR TITLE
Leia_ Add Tv Show Trailer

### DIFF
--- a/libs/data_utils.py
+++ b/libs/data_utils.py
@@ -25,7 +25,8 @@ from __future__ import absolute_import, unicode_literals
 import re, json
 from collections import OrderedDict, namedtuple
 from .utils import safe_get, logger
-from . import settings
+from . import settings, api_utils
+
 
 try:
     from typing import Optional, Text, Dict, List, Any  # pylint: disable=unused-import
@@ -244,6 +245,10 @@ def add_main_show_info(list_item, show_info, full_info=True):
             if mpaa:
                 video['Mpaa'] = settings.CERT_PREFIX + mpaa
         video['credits'] = video['writer'] = _get_credits(show_info)
+        if settings.ENABTRAILER:
+            trailer = _parse_trailer(show_info.get('videos', {}).get('results', {}))
+            if trailer:
+                video['trailer'] = trailer
         list_item = set_show_artwork(show_info, list_item)
         list_item = _add_season_info(show_info, list_item)
         list_item = _set_cast(show_info['credits']['cast'], list_item)
@@ -335,3 +340,30 @@ def parse_media_id(title):
     elif title.startswith('tvdb/') and title[5:].isdigit(): # TVDB ID
         return {'type': 'tvdb_id', 'title': title[5:]}
     return None
+
+
+def _parse_trailer(results):
+    if results:        
+        backup_keys = []       
+        for result in results:
+            if result.get('site') == 'YouTube':
+                key = result.get('key')
+                if result.get('type') == 'Trailer':                   
+                    if _check_youtube (key):                        
+                        return 'plugin://plugin.video.youtube/?action=play_video&videoid='+key  # video is available and is defined as "Trailer" by TMDB. Perfect link!                    
+                else:
+                    backup_keys.append(key)      # video is available, but NOT defined as "Trailer" by TMDB. Saving it as backup in case it doesn't find any perfect link.                                 
+        for keybackup in backup_keys:            
+            if _check_youtube (keybackup):                
+                return 'plugin://plugin.video.youtube/?action=play_video&videoid='+keybackup                    
+    return None             
+
+
+def _check_youtube (key):
+    chk_link = "https://www.youtube.com/watch?v="+key            
+    check = api_utils.load_info(chk_link, resp_type = 'not_json')
+    if not check or "Video unavailable" in check:       # video not available   
+        return False                            
+    return True
+                              
+

--- a/libs/settings.py
+++ b/libs/settings.py
@@ -75,6 +75,7 @@ source_settings = json.loads(source_params.get('pathSettings', {}))
 
 KEEPTITLE =source_settings.get('keeporiginaltitle', False)
 CATLANDSCAPE = source_settings.get('cat_landscape', True)
+ENABTRAILER = source_settings.get('enab_trailer', True)
 VERBOSELOG =  source_settings.get('verboselog', False)
 LANG = source_settings.get('language', 'en-US')
 CERT_COUNTRY = source_settings.get('tmdbcertcountry', 'us').lower()

--- a/libs/tmdb.py
+++ b/libs/tmdb.py
@@ -145,7 +145,7 @@ def load_show_info(show_id, ep_grouping=None, named_seasons=None):
         logger.debug('no cache file found, loading from scratch')
         show_url = SHOW_URL.format(show_id)
         params = TMDB_PARAMS.copy()
-        params['append_to_response'] = 'credits,content_ratings,external_ids,images'
+        params['append_to_response'] = 'credits,content_ratings,external_ids,images,videos'
         params['include_image_language'] = '%s,en,null' % settings.LANG[0:2]
         show_info = api_utils.load_info(show_url, params=params, verboselog=settings.VERBOSELOG)
         if show_info is None:

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -124,3 +124,8 @@ msgctxt "#30304"
 msgid "Also add TMDb ratings"
 msgstr ""
 
+msgctxt "#30305"
+msgid "Enable Trailer"
+msgstr ""
+
+

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -7,6 +7,7 @@
 		<setting label="30003" type="text" id="certprefix" enable="eq(-1,true)" default="Rated " />
 		<setting label="30004" type="bool" id="keeporiginaltitle" default="false" />
 		<setting label="30005" type="bool" id="cat_landscape" default="true" />
+    <setting label="30305" type="bool" id="enab_trailer" default="true" />    
 	</category>
 	<category label="30300">
 		<setting label="30301" type="labelenum" values="TMDb|IMDb|Trakt" id="ratings" default="TMDb" />


### PR DESCRIPTION
This PR is quite different from the one in Matrix.

First, when I was testing Leia, I randomly found one broken trailer link.  Then I discovered that the trailer_check function is working great when catching videos that does not exist, however there are some videos not available only in some counties, but they are good link in other countries, and the trailer_check function would not catch these videos if you are in one of those not-available countries. For example in my country,  the majority of "Better Call Saul" trailers are unavailable here, but the trailer_check func. is approving them.
So I came up with another solution and now I am not using that  "oembed YouTube" link anymore, instead I am using the normal YouTube link.

Second, to make the function more efficient, the condition  `if result.get('type') == 'Trailer'` is coming before the link is actually tested. Only if it doesn't find any "perfect" link that it will look for backups.

Please let me know your thoughts, then I can make the changes in Matrix or here.