### PR TITLE
Making Matrix equal to Leia

### DIFF
--- a/libs/tmdb.py
+++ b/libs/tmdb.py
@@ -406,16 +406,3 @@ def _image_sort(images, image_type):
         return lang_pref + lang_en + lang_null
     else:
         return lang_pref + lang_null + lang_en
-
-
-def _convert_ext_id(ext_provider, ext_id):
-    providers_dict = {'imdb' : 'imdb_id',
-                     'thetvdb' : 'tvdb_id',
-                     'tvdb' : 'tvdb_id'}
-    show_url = FIND_URL.format(ext_id)
-    params = TMDB_PARAMS.copy()
-    params['external_source'] = providers_dict[ext_provider]
-    show_info = api_utils.load_info(show_url, params=params)
-    if show_info:
-        return show_info.get('tv_results')[0].get('id')
-    return None


### PR DESCRIPTION
Sorry  for the confusion @pkscout. I think you didn't read my two PRs in Leia. Both PR are slightly different from Matrix, so now I am creating this PR to make Matrix and Leia equal again. Below are the full explanations I gave when I PR in Leia. The trailer_check function is more efficient now and also, we don't have to import those many classes into data_utils anymore.

 LEIA TV SHOW PR:
First, when I was testing Leia, I randomly found one broken trailer link. Then I discovered that the trailer_check function is working great when catching videos that does not exist, however there are some videos not available only in some counties, but they are good link in other countries, and the trailer_check function would not catch these videos if you are in one of those not-available countries. For example in my country, the majority of "Better Call Saul" trailers are unavailable here, but the trailer_check func. is approving them.
So I came up with another solution and now I am not using that "oembed YouTube" link anymore, instead I am using the normal YouTube link.

Second, to make the function more efficient, the condition if `result.get('type') == 'Trailer'` is coming before the link is actually tested. Only if it doesn't find any "perfect" link that it will look for backups.
_______________________________________________________________________________

 LEIA "parse_nfo_url" AND "convert external ID" PR:
Because of python 2, I wasn't able to import tmdb into data_utils, so I instead, I imported api_utils, and create the _convert_ext_id() function in data_utils. Apart of that, it is all the same.