### PR TITLE
Separate network and country check

### DIFF
--- a/libs/data_utils.py
+++ b/libs/data_utils.py
@@ -247,10 +247,10 @@ def add_main_show_info(list_item, show_info, full_info=True):
             country = None
         if network and country and settings.STUDIOCOUNTRY:
             video['studio'] = '{0} ({1})'.format(network['name'], country)
-            video['country'] = country
-        elif network and country:
+        elif network:
             video['studio'] = network['name']
-            video['country'] = country           
+        if country:
+            video['country'] = country        
         content_ratings = show_info.get('content_ratings', {}).get('results', {})
         if content_ratings:
             mpaa = ''


### PR DESCRIPTION
Separate network and country check as sometimes we don't get both as in the case of Netflix programs.

```
"networks": [
{
"name": "Netflix",
"id": 213,
"logo_path": "/wwemzKWzjKYJFfCeiB57q3r4Bcm.png",
"origin_country": ""
}
```

Which means without the country the network is never set.