### PR TITLE
Change default ID to imdb

### DIFF
--- a/libs/data_utils.py
+++ b/libs/data_utils.py
@@ -131,7 +131,7 @@ def _set_unique_ids(ext_ids, list_item):
         if key in VALIDEXTIDS and value:
             key = key[:-3]
             unique_ids[key] = str(value)
-    list_item.setUniqueIDs(unique_ids, 'tmdb')
+    list_item.setUniqueIDs(unique_ids, 'imdb')
     return list_item
 
 


### PR DESCRIPTION
During my migration to Matrix, it came to my attention that this new default scraper sets the `ListItem.IMDBNumber` InfoLabel to the TMDb ID instead.

For example, after scanning (a subset of) my library in using the current version of this scraper, I ran the following JSON-RPC command:
`{"jsonrpc":"2.0","id":15,"method":"VideoLibrary.GetTVShows","params":{"properties":["uniqueid","imdbnumber"]}}`
And got this response back:
```json
{
    "id": 15,
    "jsonrpc": "2.0",
    "result": {
        "limits": {
            "end": 1,
            "start": 0,
            "total": 1
        },
        "tvshows": [
           {
                "imdbnumber": "60625",
                "label": "Rick and Morty",
                "tvshowid": 1,
                "uniqueid": {
                    "imdb": "tt2861424",
                    "tmdb": "60625",
                    "tvdb": "275274"
                }
            }
        ]
    }
}
```
Which shows that the IMDb ID is incorrectly set, and instead matches the "uniqueid" key for TMDb. A log can be found here: https://pastebin.com/w8NvT4pN

In this PR, I have fixed this issue by simply changing the "default" ID (as described [in the docs](https://codedocs.xyz/AlwinEsch/kodi/group__python__xbmcgui__listitem.html#ga7fc2ecd77b8d0032cc68eee6b4c9d6a2) to `'imdb'` instead of `'tmdb'`.

This results in the IMDb ID being set correctly, and when making that same JSON-RPC call:
```json
{
    "id": 5,
    "jsonrpc": "2.0",
    "result": {
        "limits": {
            "end": 1,
            "start": 0,
            "total": 1
        },
        "tvshows": [
           {
                "imdbnumber": "tt2861424",
                "label": "Rick and Morty",
                "tvshowid": 1,
                "uniqueid": {
                    "imdb": "tt2861424",
                    "tmdb": "60625",
                    "tvdb": "275274"
                }
            }
        ]
    }
}
```
Finally, a log of that can be found here: https://pastebin.com/TDNy722f

Unless there is a particular reason that this change was made, it seems odd for this inconsistency to be maintained, so I hope that this PR will be considered valid.

I have also made a PR to the Leia branch, in #40.