### PR TITLE
Fix ignoring NFO files with TVDB artwork URLs

### DIFF
--- a/libs/data_utils.py
+++ b/libs/data_utils.py
@@ -50,7 +50,8 @@ SHOW_ID_REGEXPS = (
     r'(tmdb)\.org/./tv/(\d+)',                            # TMDB_http_link
     r'(imdb)\.com/.+/(tt\d+)',                            # IMDB_http_link
     r'(thetvdb)\.com.+&id=(\d+)',                         # TheTVDB_http_link
-    r'(thetvdb)\.com/.*?series/(\d+)',                    # TheTVDB_http_link
+    r'(thetvdb)\.com/series/(\d+)',                       # TheTVDB_http_link
+    r'(thetvdb)\.com/api/.*series/(\d+)',                 # TheTVDB_http_link
     r'(thetvdb)\.com/.*?"id":(\d+)',                      # TheTVDB_http_link
     r'<uniqueid.+?type="(tvdb|imdb)".*?>([t\d]+?)</uniqueid>'
 )


### PR DESCRIPTION
Too-aggressive regex was misidentifying certain artwork URLs as [parsing URLs](https://kodi.wiki/view/NFO_files/Parsing).

Fixes https://github.com/xbmc/xbmc/issues/19845

The second line with `/api/` identifies classic TVDB v1 API **episodeguide** values.

@pkscout @KarellenX @romanvm
