### PR TITLE
Separation of primary language definition for details and images

### DIFF
--- a/libs/data_utils.py
+++ b/libs/data_utils.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     pass
 
-TMDB_PARAMS = {'api_key': settings.TMDB_CLOWNCAR, 'language': settings.LANG}
+TMDB_PARAMS = {'api_key': settings.TMDB_CLOWNCAR, 'language': settings.LANG_DETAILS}
 BASE_URL = 'https://api.themoviedb.org/3/{}'
 FIND_URL = BASE_URL.format('find/{}')
 TAG_RE = re.compile(r'<[^>]+>')
@@ -431,7 +431,7 @@ def _parse_trailer(results):
         elif settings.PLAYERSOPT == 'youtube':
             addon_player = 'plugin://plugin.video.youtube/?action=play_video&videoid='
         backup_keys = []
-        for video_lang in [settings.LANG[0:2], 'en']:
+        for video_lang in [settings.LANG_DETAILS[0:2], 'en']:
             for result in results:
                 if result.get('site') == 'YouTube' and result.get('iso_639_1') == video_lang:
                     key = result.get('key')

--- a/libs/settings.py
+++ b/libs/settings.py
@@ -86,7 +86,8 @@ PLAYERSOPT = source_settings.get(
     'players_opt', ADDON.getSettingString('players_opt')).lower()
 VERBOSELOG = source_settings.get(
     'verboselog', ADDON.getSettingBool('verboselog'))
-LANG = source_settings.get('language', ADDON.getSettingString('language'))
+LANG_DETAILS = source_settings.get('languageDetails', ADDON.getSettingString('languageDetails'))
+LANG_IMAGES = source_settings.get('languageImages', ADDON.getSettingString('languageImages'))
 CERT_COUNTRY = source_settings.get(
     'tmdbcertcountry', ADDON.getSettingString('tmdbcertcountry')).lower()
 SAVETAGS = source_settings.get(

--- a/libs/settings.py
+++ b/libs/settings.py
@@ -86,13 +86,17 @@ PLAYERSOPT = source_settings.get(
     'players_opt', ADDON.getSettingString('players_opt')).lower()
 VERBOSELOG = source_settings.get(
     'verboselog', ADDON.getSettingBool('verboselog'))
-LANG_DETAILS = source_settings.get('languageDetails', ADDON.getSettingString('languageDetails'))
-LANG_IMAGES = source_settings.get('languageImages', ADDON.getSettingString('languageImages'))
 CERT_COUNTRY = source_settings.get(
     'tmdbcertcountry', ADDON.getSettingString('tmdbcertcountry')).lower()
 SAVETAGS = source_settings.get(
     'keywordsastags', ADDON.getSettingBool('keywordsastags'))
 IMAGEROOTURL, PREVIEWROOTURL = _load_base_urls()
+
+LANG_DETAILS = source_settings.get('languageDetails', ADDON.getSettingString('languageDetails'))
+if source_settings.get('usedifferentlangforimages', ADDON.getSettingBool('usedifferentlangforimages')):
+    LANG_IMAGES = source_settings.get('languageImages', ADDON.getSettingString('languageImages'))
+else:
+    LANG_IMAGES = LANG_DETAILS
 
 if source_settings.get('usecertprefix', ADDON.getSettingBool('usecertprefix')):
     CERT_PREFIX = source_settings.get(

--- a/libs/tmdb.py
+++ b/libs/tmdb.py
@@ -37,7 +37,7 @@ HEADERS = (
 )
 api_utils.set_headers(dict(HEADERS))
 
-TMDB_PARAMS = {'api_key': settings.TMDB_CLOWNCAR, 'language': settings.LANG}
+TMDB_PARAMS = {'api_key': settings.TMDB_CLOWNCAR, 'language': settings.LANG_DETAILS}
 BASE_URL = 'https://api.themoviedb.org/3/{}'
 EPISODE_GROUP_URL = BASE_URL.format('tv/episode_group/{}')
 SEARCH_URL = BASE_URL.format('search/tv')
@@ -156,20 +156,20 @@ def load_show_info(show_id, ep_grouping=None, named_seasons=None):
         show_url = SHOW_URL.format(show_id)
         params = TMDB_PARAMS.copy()
         params['append_to_response'] = 'credits,content_ratings,external_ids,images,videos,keywords'
-        params['include_image_language'] = '%s,en,null' % settings.LANG[0:2]
-        params['include_video_language'] = '%s,en,null' % settings.LANG[0:2]
+        params['include_image_language'] = '%s,en,null' % settings.LANG_IMAGES[0:2]
+        params['include_video_language'] = '%s,en,null' % settings.LANG_DETAILS[0:2]
         show_info = api_utils.load_info(
             show_url, params=params, verboselog=settings.VERBOSELOG)
         if show_info is None:
             return None
-        if show_info['overview'] == '' and settings.LANG != 'en-US':
+        if show_info['overview'] == '' and settings.LANG_DETAILS != 'en-US':
             params['language'] = 'en-US'
             del params['append_to_response']
             show_info_backup = api_utils.load_info(
                 show_url, params=params, verboselog=settings.VERBOSELOG)
             if show_info_backup is not None:
                 show_info['overview'] = show_info_backup.get('overview', '')
-            params['language'] = settings.LANG
+            params['language'] = settings.LANG_DETAILS
         season_map = {}
         params['append_to_response'] = 'credits,images'
         for season in show_info.get('seasons', []):
@@ -177,11 +177,11 @@ def load_show_info(show_id, ep_grouping=None, named_seasons=None):
                 show_id, season.get('season_number', 0))
             season_info = api_utils.load_info(
                 season_url, params=params, default={}, verboselog=settings.VERBOSELOG)
-            if (season_info.get('overview', '') == '' or season_info.get('name', '').lower().startswith('season')) and settings.LANG != 'en-US':
+            if (season_info.get('overview', '') == '' or season_info.get('name', '').lower().startswith('season')) and settings.LANG_DETAILS != 'en-US':
                 params['language'] = 'en-US'
                 season_info_backup = api_utils.load_info(
                     season_url, params=params, default={}, verboselog=settings.VERBOSELOG)
-                params['language'] = settings.LANG
+                params['language'] = settings.LANG_DETAILS
                 if season_info.get('overview', '') == '':
                     season_info['overview'] = season_info_backup.get(
                         'overview', '')
@@ -240,7 +240,7 @@ def load_episode_info(show_id, episode_id):
             show_info['id'], episode_info['org_seasonnum'], episode_info['org_epnum'])
         params = TMDB_PARAMS.copy()
         params['append_to_response'] = 'credits,external_ids,images'
-        params['include_image_language'] = '%s,en,null' % settings.LANG[0:2]
+        params['include_image_language'] = '%s,en,null' % settings.LANG_IMAGES[0:2]
         ep_return = api_utils.load_info(
             ep_url, params=params, verboselog=settings.VERBOSELOG)
         if ep_return is None:
@@ -256,7 +256,7 @@ def load_episode_info(show_id, episode_id):
             bad_return_name = True
         if ep_return.get('overview', '') == '':
             bad_return_overview = True
-        if (bad_return_overview or bad_return_name) and settings.LANG != 'en-US':
+        if (bad_return_overview or bad_return_name) and settings.LANG_DETAILS != 'en-US':
             params['language'] = 'en-US'
             del params['append_to_response']
             ep_return_backup = api_utils.load_info(
@@ -344,7 +344,7 @@ def load_fanarttv_art(show_info):
                 if lang == '' or lang == '00':
                     lang = None
                 filepath = ''
-                if lang is None or lang == settings.LANG[0:2] or lang == 'en':
+                if lang is None or lang == settings.LANG_DETAILS[0:2] or lang == 'en':
                     filepath = item.get('url')
                 if filepath:
                     if tmdb_type.startswith('season'):
@@ -450,7 +450,7 @@ def _image_sort(images, image_type):
     firstimage = True
     for image in images:
         image_lang = image.get('iso_639_1')
-        if image_lang == settings.LANG[0:2]:
+        if image_lang == settings.LANG_DETAILS[0:2]:
             lang_pref.append(image)
         elif image_lang == 'en':
             lang_en.append(image)

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -25,7 +25,7 @@ msgid "The Movie Database (TMDb) is a community built movie and TV database. Eve
 msgstr ""
 
 msgctxt "#30000"
-msgid "Preferred language (Details)"
+msgid "Preferred language"
 msgstr ""
 
 msgctxt "#30001"
@@ -58,6 +58,10 @@ msgstr ""
 
 msgctxt "#30008"
 msgid "Preferred language (Images)"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Use different language for images"
 msgstr ""
 
 # empty strings from 30009 to 30099

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -25,7 +25,7 @@ msgid "The Movie Database (TMDb) is a community built movie and TV database. Eve
 msgstr ""
 
 msgctxt "#30000"
-msgid "Preferred language"
+msgid "Preferred language (Details)"
 msgstr ""
 
 msgctxt "#30001"
@@ -56,7 +56,11 @@ msgctxt "#30007"
 msgid "Add keywords as tags"
 msgstr ""
 
-# empty strings from 30006 to 30099
+msgctxt "#30008"
+msgid "Preferred language (Images)"
+msgstr ""
+
+# empty strings from 30009 to 30099
 
 msgctxt "#30100"
 msgid "Fanart.tv"

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -3,7 +3,7 @@
 	<section id="metadata.tvshows.themoviedb.org.python">
 		<category id="general" label="128" help="">
 			<group id="1">
-				<setting id="language" type="string" label="30000" help="">
+				<setting id="languageDetails" type="string" label="30000" help="">
 					<level>0</level>
 					<default>en-US</default>
 					<constraints>
@@ -68,6 +68,73 @@
 					</constraints>
 					<control type="list" format="string">
 						<heading>30000</heading>
+					</control>
+				</setting>
+				<setting id="languageImages" type="string" label="30008" help="">
+					<level>0</level>
+					<default>en-US</default>
+					<constraints>
+						<options>
+							<option>ar-AE</option>
+							<option>ar-SA</option>
+							<option>be-BY</option>
+							<option>bg-BG</option>
+							<option>bn-BD</option>
+							<option>ca-ES</option>
+							<option>ch-GU</option>
+							<option>cs-CZ</option>
+							<option>da-DK</option>
+							<option>de-DE</option>
+							<option>el-GR</option>
+							<option>en-US</option>
+							<option>eo-EO</option>
+							<option>es-ES</option>
+							<option>es-MX</option>
+							<option>et-EE</option>
+							<option>eu-ES</option>
+							<option>fa-IR</option>
+							<option>fi-FI</option>
+							<option>fr-CA</option>
+							<option>fr-FR</option>
+							<option>gl-ES</option>
+							<option>he-IL</option>
+							<option>hi-IN</option>
+							<option>hr-HR</option>
+							<option>hu-HU</option>
+							<option>id-ID</option>
+							<option>it-IT</option>
+							<option>ja-JP</option>
+							<option>ka-GE</option>
+							<option>kn-IN</option>
+							<option>ko-KR</option>
+							<option>lt-LT</option>
+							<option>lv-LV</option>
+							<option>ml-IN</option>
+							<option>nb-NO</option>
+							<option>nl-NL</option>
+							<option>no-NO</option>
+							<option>pl-PL</option>
+							<option>pt-BR</option>
+							<option>pt-PT</option>
+							<option>ro-RO</option>
+							<option>ru-RU</option>
+							<option>sk-SK</option>
+							<option>sl-SI</option>
+							<option>sr-RS</option>
+							<option>sv-SE</option>
+							<option>ta-IN</option>
+							<option>te-IN</option>
+							<option>th-TH</option>
+							<option>tr-TR</option>
+							<option>uk-UA</option>
+							<option>vi-VN</option>
+							<option>zh-CN</option>
+							<option>zh-HK</option>
+							<option>zh-TW</option>
+						</options>
+					</constraints>
+					<control type="list" format="string">
+						<heading>30008</heading>
 					</control>
 				</setting>
 				<setting id="tmdbcertcountry" type="string" label="30001" help="">

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -70,9 +70,19 @@
 						<heading>30000</heading>
 					</control>
 				</setting>
+				<setting id="usedifferentlangforimages" type="boolean" label="30009" help="">
+					<level>0</level>
+					<default>false</default>
+					<control type="toggle"/>
+				</setting>
 				<setting id="languageImages" type="string" label="30008" help="">
 					<level>0</level>
 					<default>en-US</default>
+					<dependencies>
+						<dependency type="visible">
+							<condition operator="is" setting="usedifferentlangforimages">true</condition>
+						</dependency>
+					</dependencies>
 					<constraints>
 						<options>
 							<option>ar-AE</option>


### PR DESCRIPTION
metadata.tvshows.themoviedb.org.python
(Based on version 1.6.5)

Separation of primary language definition for details and images.

With this feature, user can get Tv Show info in one language and images in another language.

Tested on Kodi Nexus 20.1 (Windows)