### PR TITLE
Support for filename identifiers

### DIFF
--- a/libs/actions.py
+++ b/libs/actions.py
@@ -94,6 +94,24 @@ def get_show_id_from_nfo(nfo):
             )
 
 
+def get_show_id(unique_ids):
+    """
+    Get show ID by unique IDs
+
+    In case there is a tmdb identifier in the unique IDs, use that.
+    Else use the find_by_id method to get the show ID by an external ID.
+
+    :param unique_ids: dictionary of unique IDs
+    """
+    if unique_ids.get('tmdb'):
+        return unique_ids['tmdb']
+    else:
+        res = tmdb.find_by_id(unique_ids)
+        if len(res) > 0:
+            return res[0].get('id')
+    return None
+
+
 def get_details(show_id):
     # type: (Text) -> None
     """Get details about a specific show"""
@@ -226,7 +244,9 @@ def router(paramstring):
         get_show_id_from_nfo(params['nfo'])
     elif params['action'] == 'getdetails':
         logger.debug('performing getdetails action')
-        get_details(params['url'])
+        show_id = params.get('url') or get_show_id(json.loads(params.get('uniqueIDs')))
+        if show_id:
+            get_details(show_id)
     elif params['action'] == 'getepisodelist':
         logger.debug('performing getepisodelist action')
         get_episode_list(params['url'])

--- a/libs/tmdb.py
+++ b/libs/tmdb.py
@@ -93,6 +93,24 @@ def search_show(title, year=None):
     return results
 
 
+def find_by_id(unique_ids):
+    """
+    Find a show by external IDs
+    :param unique_ids: dict of external IDs
+    :return: a list with found TV shows
+    """
+    supported_ids = ['imdb', 'facebook', 'instagram', 'tvdb', 'tiktok', 'twitter', 'wikidata', 'youtube']
+    params = TMDB_PARAMS.copy()
+    for key, value in unique_ids.items():
+        if key in supported_ids:
+            params['external_source'] = key + '_id'
+            search_url = FIND_URL.format(value)
+            resp = api_utils.load_info(search_url, params=params, verboselog=settings.VERBOSELOG)
+            if resp is not None:
+                return resp.get('tv_results', [])
+    return []
+
+
 def load_episode_list(show_info, season_map, ep_grouping):
     # type: (InfoType, Dict, Text) -> Optional[InfoType]
     """get the IMDB ratings details"""


### PR DESCRIPTION
Add the needed changes for looking up by unique identifiers required for supporting [filename identifiers](https://github.com/xbmc/xbmc/pull/23840). The current implementation tries to find a `tmdb` first falling back to [find by id](https://developer.themoviedb.org/reference/find-by-id) if needed to support other identifiers (`imdb` and `tvdb` being the most relevant).

For reference [tmdb movies](https://github.com/xbmc/metadata.themoviedb.org.python/pull/205) implementation