### PR TITLE
Update YouTube plugin url used for trailers

### DIFF
--- a/libs/data_utils.py
+++ b/libs/data_utils.py
@@ -429,7 +429,7 @@ def _parse_trailer(results):
         if settings.PLAYERSOPT == 'tubed':
             addon_player = 'plugin://plugin.video.tubed/?mode=play&video_id='
         elif settings.PLAYERSOPT == 'youtube':
-            addon_player = 'plugin://plugin.video.youtube/?action=play_video&videoid='
+            addon_player = 'plugin://plugin.video.youtube/play/?video_id='
         backup_keys = []
         for video_lang in [settings.LANG_DETAILS[0:2], 'en']:
             for result in results:


### PR DESCRIPTION
The plugin.video.youtube addon has supported a newer url format for quite some time.

While the old format is meant to be deprecated, the fact that it is saved in the Kodi video database means that actually disabling support for the old query parameters may not actually be feasible.

Regardless, updating the format used by the Kodi scrapers would be the first step towards doing so.

Can also make the same update for the matrix branch if that is still being updated?